### PR TITLE
Fix and Workarounds for BigQueryHook

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -138,7 +138,10 @@ class BigQueryPandasConnector(GbqConnector):
     without forcing a three legged OAuth connection. Instead, we can inject
     service account credentials into the binding.
     """
-    def __init__(self, project_id, service, reauth=False, verbose=False, dialect='legacy'):
+    def __init__(self, project_id, service, reauth=False, verbose=False, dialect='legacy', **kwargs):
+        super(BigQueryPandasConnector, self).__init__(project_id=project_id,
+                                                      reauth=reauth,
+                                                      verbose=verbose)
         gbq_check_google_client_version()
         gbq_test_google_api_imports()
         self.project_id = project_id


### PR DESCRIPTION
#### What does this PR do?
Adds a workaround for two errors found in the BigQueryHook class. 
1) A missed call to super to initialize the parent class in `BigQueryPandasConnector`
2) A workaround when `_parse_data` from `pandas_gbq` fails to parse a result with a single column

#### What are the relevant JIRA tickets?
Workaround in Airflow for [pandas-gbq issue 114](https://github.com/pydata/pandas-gbq/issues/114)

#### Where should the reviewer start?
Look at `airflow/contrib/hooks/bigquery_hook.py`