### PR TITLE
Include call to parent class init method to fix AttributeError exception

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -138,7 +138,10 @@ class BigQueryPandasConnector(GbqConnector):
     without forcing a three legged OAuth connection. Instead, we can inject
     service account credentials into the binding.
     """
-    def __init__(self, project_id, service, reauth=False, verbose=False, dialect='legacy'):
+    def __init__(self, project_id, service, reauth=False, verbose=False, dialect='legacy', **kwargs):
+        super(BigQueryPandasConnector, self).__init__(project_id=project_id,
+                                                      reauth=reauth,
+                                                      verbose=verbose)
         gbq_check_google_client_version()
         gbq_test_google_api_imports()
         self.project_id = project_id


### PR DESCRIPTION
The init method was missing a call to `super()` to initialize the parent class.