### PR TITLE
fix/email retry template

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1806,7 +1806,7 @@ class TaskInstance(Base, LoggingMixin):
             "Host: {self.hostname}<br>"
             "Log file: {self.log_filepath}<br>"
             "Mark success: <a href='{self.mark_success_url}'>Link</a><br>"
-        ).format(try_number=self.try_number, max_tries=self.max_tries + 1, **locals())
+        ).format(try_number=self._try_number, max_tries=self.max_tries + 1, **locals())
         send_email(task.email, title, body)
 
     def set_duration(self):


### PR DESCRIPTION
Fix email template sent on TaskInstance error.

* `try_number` is a property of the TaskInstance (see lines [838](https://github.com/wizeline/incubator-airflow/blob/fix/email_retry_template/airflow/models.py#L838) to [854](https://github.com/wizeline/incubator-airflow/blob/fix/email_retry_template/airflow/models.py#L854) @ models.py:TaskInstance)
     - It is initialized as 0 (line [821](https://github.com/wizeline/incubator-airflow/blob/fix/email_retry_template/airflow/models.py#L821))
          - Once the task is ready for execution it adds +1 to previous value everytime (line [1435](https://github.com/wizeline/incubator-airflow/blob/fix/email_retry_template/airflow/models.py#L1435) )
     - When TaskInstance.State IS State.RUNNING ==> property returns *stored_value*
     - When TaskInstance.State IS NOT State.RUNNING ==> property returns *stored_value + 1*

The `email_alert` function (lines [1795](https://github.com/wizeline/incubator-airflow/blob/fix/email_retry_template/airflow/models.py#L1795) to [1810](https://github.com/wizeline/incubator-airflow/blob/fix/email_retry_template/airflow/models.py#L1810))  is used right after changing the state of the TaskInstance to either `UP_FOR_RETRY` or `FAILED` (lines [1642](https://github.com/wizeline/incubator-airflow/blob/fix/email_retry_template/airflow/models.py#L1642) and [1647](https://github.com/wizeline/incubator-airflow/blob/fix/email_retry_template/airflow/models.py#L1647)) . It was using the direct property `try_number`, thus it was getting an extra +1 in its value.