### PR TITLE
Fix parameter to consider sent template

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -81,7 +81,7 @@ class TriggerDagRunOperator(BaseOperator):
             trigger_dag(dag_id=self.trigger_dag_id,
                         run_id=dro.run_id,
                         conf=json.dumps(dro.payload),
-                        execution_date=self.execution_date,
+                        execution_date=execution_date,  # Overrides default with exec_date_template
                         replace_microseconds=False)
         else:
             self.log.info("Criteria not met, moving on")


### PR DESCRIPTION
The upstream value does not take into account the modified value of execution_date as done a few lines above in the same function.

This was detected while testing Airflow 1.10 in NewsIQ DEV environment. 